### PR TITLE
short_name obbligatorio per groups può far fallire il seeding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ gem 'rails-footnotes', '>=4.1.7'
 gem 'sneaky-save',  '>=0.1.0'
 
 gem 'thin'
+
+gem 'amoeba'

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -684,6 +684,15 @@ puts "###################### list_oa_ogtd inizio"
     redirect_to fond_units_url(@unit.root_fond_id), :notice => "Scheda eliminata"
   end
 
+  def duplicate
+    @unit = Unit.find(params[:id])
+    copy = @unit.amoeba_dup
+    copy.save
+
+    # OPTIMIZE: rivedere redirect
+    redirect_to request.referrer, :notice => 'Scheda duplicata'
+  end
+
 # Upgrade 2.1.0 inizio
 	def sc2_voc_list
 		voc_name = params["voc"]
@@ -702,7 +711,7 @@ puts "###################### list_oa_ogtd inizio"
           where({ "sc2_vocabularies.name" => "#{voc_name}" }).
           order("term_key")
       end
-			
+
 			voc_terms = []
 			if is_voc_add_empty
 				voc_terms = [{ :term_key => "", :term_value => "" }]
@@ -762,4 +771,3 @@ puts "###################### list_oa_ogtd inizio"
 # Upgrade 2.0.0 fine
 
 end
-

--- a/app/models/sc2_author.rb
+++ b/app/models/sc2_author.rb
@@ -6,6 +6,10 @@ class Sc2Author < ActiveRecord::Base
 
 	accepts_nested_attributes_for :sc2_attribution_reasons, :allow_destroy => true, :reject_if => :sc2_attribution_reasons_reject_if
 
+  amoeba do
+    enable
+  end
+  
   def sc2_attribution_reasons_reject_if(attributes)
     exists = attributes[:id].present?
     empty = attributes[:autm].blank?

--- a/app/models/sc2_commission.rb
+++ b/app/models/sc2_commission.rb
@@ -4,7 +4,11 @@ class Sc2Commission < ActiveRecord::Base
 
   has_many :sc2_commission_names, :dependent => :destroy
 
-# nella soluzione che non usa sc2_commission_names_reject_if) non si cancella il record nel db con la seguente sequenza: salvo un record con un valore, poi lo svuoto nell'interfaccia senza usare il check per la cancellazione e salvo. Ma è un problema per tutti i campi ripetitivi di archimista, non solo per cmmn. E' più giusto usando sc2_commission_names_reject_if, ma si dovrebbe estendere anche a tutti gli altri casi. Per il momento si lascia la soluzione semplice e si fa in modoe che venga usato il check per cancellare i record vuoti
+  amoeba do
+    enable
+  end
+
+# nella soluzione che non usa sc2_commission_names_reject_if) non si cancella il record nel db con la seguente sequenza: salvo un record con un valore, poi lo svuoto nell'interfaccia senza usare il check per la cancellazione e salvo. Ma e' un problema per tutti i campi ripetitivi di archimista, non solo per cmmn. E' piu' giusto usando sc2_commission_names_reject_if, ma si dovrebbe estendere anche a tutti gli altri casi. Per il momento si lascia la soluzione semplice e si fa in modoe che venga usato il check per cancellare i record vuoti
   accepts_nested_attributes_for :sc2_commission_names, :allow_destroy => true, :reject_if => proc { |a| a['cmmn'].blank? }
 #  accepts_nested_attributes_for :sc2_commission_names, :allow_destroy => true, :reject_if => :sc2_commission_names_reject_if
   def sc2_commission_names_reject_if(attributes)

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -92,6 +92,16 @@ class Unit < ActiveRecord::Base
 	accepts_nested_attributes_for :sc2_techniques, :allow_destroy => true, :reject_if => proc { |a| a['mtct'].blank? }
   accepts_nested_attributes_for :sc2_scales, :allow_destroy => true, :reject_if => proc { |a| a['sca'].blank? }
 
+  amoeba do
+    enable
+    exclude_association :events # necessario altrimenti duplica le date
+    customize([
+      lambda do |orig, copy|
+        copy.position = orig.position + 1
+      end
+      ])
+  end
+
   def sc2_authors_reject_if(attributes)
     exists = attributes[:id].present?
     empty = attributes[:autr].blank? && attributes[:autn].blank? && attributes[:auta].blank?
@@ -233,7 +243,7 @@ class Unit < ActiveRecord::Base
     errors.add_to_base :not_allowed_ancestry_depth if ancestry_depth > MAX_LEVEL_OF_NODES
   end
 
-  # Scopes  
+  # Scopes
 # Upgrade 2.0.0 inizio
 =begin
   named_scope :list, :select => "units.id, units.sequence_number, units.reference_number,

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -111,6 +111,7 @@
           <% end %>
           <div class="unit-actions">
             <%= link_to t('show'), unit %> |
+            <%= link_to "Duplica", duplicate_unit_path(unit) %> |
 <%# Upgrade 2.0.0 inizio %>
             <%#= link_to t('destroy'), unit, :confirm => t('are_you_sure'), :method => :delete %>
             <%= link_to t('destroy'), unit, data: {:confirm => t('are_you_sure')}, :method => :delete %> |
@@ -147,4 +148,3 @@
 
 <%# OPTIMIZE: forse meglio edit-level-container, anche in considerazione di prossima probabile funzionalità "Sposta..." (prima di | dopo di) %>
 <div id="move-container"></div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
     resources :digital_objects, :except => [:show, :destroy]
   end
 
-  resources :units, :except => [:new] do
+  resources :units, :except => [:new] do :dupli
     member do
       put   :ajax_update
       patch :ajax_update
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       get   :move
       post  :move_down
       post  :move_up
+      get   :duplicate
     end
     collection do
       get :list_oa_mtc
@@ -108,7 +109,7 @@ Rails.application.routes.draw do
   end
 
   resources :creators do
-    collection do 
+    collection do
       get :list
     end
     resources :digital_objects, :except => [:show, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
     resources :digital_objects, :except => [:show, :destroy]
   end
 
-  resources :units, :except => [:new] do :dupli
+  resources :units, :except => [:new] do
     member do
       put   :ajax_update
       patch :ajax_update

--- a/db/seeds/groups.json
+++ b/db/seeds/groups.json
@@ -1,1 +1,1 @@
-{"name":"default"}
+{"name":"default", "short_name":"default"}


### PR DESCRIPTION
fix installazione ex novo su windows da sorgente, lamenta l'assenza di short_name per i gruppi in seed
